### PR TITLE
Increase CF app memory to 256MB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: teaching-vacancies-prototype
-  memory: 128M
+  memory: 256M
   buildpacks:
   - nodejs_buildpack
   env:


### PR DESCRIPTION
The app occasionally fails to start due to the initial boot step taking
up too much memory. This should sort it.