### PR TITLE
Add upload to apply for job step

### DIFF
--- a/app/views/create-a-job.html
+++ b/app/views/create-a-job.html
@@ -28,8 +28,8 @@
     {% endif %}
   {% endset %}
 
-    <h1 class="govuk-heading-m govuk-!-margin-bottom-0">Create a job listing {{ SchoolName }}</h1>
-    <span class="govuk-caption-m govuk-!-margin-bottom-5">{% if isMultiSchool == "true" %}Step {{ activePageNumber }} of 10{% else %}Step {{ activePageNumber }} of 9{% endif %}</span>
+    <span class="govuk-caption-m govuk-!-margin-bottom-0">{% if isMultiSchool == "true" %}Step {{ activePageNumber }} of 10{% else %}Step {{ activePageNumber }} of 9{% endif %}</span>
+    <h1 class="govuk-heading-m govuk-!-margin-bottom-5">Create a job listing {{ SchoolName }}</h1>
 </div>
 
 {# <main class="govuk-main-wrapper"> #}

--- a/app/views/prototypes/create-a-job/6c-applying-outside-tvs.html
+++ b/app/views/prototypes/create-a-job/6c-applying-outside-tvs.html
@@ -38,7 +38,7 @@
             }
           } | decorateAttributes(data, "data.job.applicationLink")) }}
 
-          {# <h3 class="">Upload an application form (optional)</h3>
+          <h3 class="">Upload an application form (optional)</h3>
           <p class="govuk-body">The file must be:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>
@@ -55,7 +55,7 @@
           {{ govukButton({
             text: "Select a file",
             classes: "govuk-button--secondary"
-          }) }} #}
+          }) }}
 
           {{ govukInput({
             label: {

--- a/app/views/prototypes/create-a-job/7-supporting-documents.html
+++ b/app/views/prototypes/create-a-job/7-supporting-documents.html
@@ -16,7 +16,7 @@
       <h2 class="govuk-heading-l">Supporting documents</h2>
       <h3 class="govuk-heading-s">Upload files</h3>
 
-      <p class="govuk-body">If you need candidates to complete an application form or any other documents, upload your attachments. You can also add other files that may be useful such as detailed job descriptions or person specifications.</p>
+      <p class="govuk-body">You can upload files such as a job description or person specification.</p>
       <p class="govuk-body">You can upload as many files as you like. Each file must be:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>


### PR DESCRIPTION
This PR includes:

## An for upload input on one of the how to apply steps

![localhost_3000_prototypes_create-a-job_6c-applying-outside-tvs (4)](https://user-images.githubusercontent.com/1108991/141280956-fc4516c9-6b22-4582-bf4e-effbad43ae98.png)

## Updated (simplified) copy on the supporting documents screen

![localhost_3000_prototypes_create-a-job_6c-applying-outside-tvs (4)](https://user-images.githubusercontent.com/1108991/141281059-371d2e58-26b5-471c-8381-f6f85a3c0e99.png)

## Typography update

In the design system captions generally go above headings, not below. Updating for consistency and it looks more _right_ this way to me. 

Before
![Screenshot 2021-11-11 at 10 19 23](https://user-images.githubusercontent.com/1108991/141281301-ff092792-5519-4b88-88d7-3955767e1d50.png)

After
![Screenshot 2021-11-11 at 10 19 10](https://user-images.githubusercontent.com/1108991/141281324-0150757e-63ec-4826-9ec1-b98ee1fa825d.png)
 
